### PR TITLE
Add mysqlclient to Extra-Libraries

### DIFF
--- a/HDBC-mysql.cabal
+++ b/HDBC-mysql.cabal
@@ -32,6 +32,7 @@ library
     time,
     utf8-string
   ghc-options:      -Wall
+  Extra-Libraries: mysqlclient
 
 source-repository head
   type:     git


### PR DESCRIPTION
Adding mysqlclient to Extra-Libraries to link it to a generated so. This patch fixes #12.